### PR TITLE
Minor change to disable cascaded table dropping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.*
+bin/
 target
 .idea
 *.iml

--- a/src/main/java/org/hibernate/dialect/SQLiteDialect.java
+++ b/src/main/java/org/hibernate/dialect/SQLiteDialect.java
@@ -321,7 +321,7 @@ public class SQLiteDialect extends Dialect {
 
   @Override
   public String getCascadeConstraintsString() {
-    return " cascade";
+    return " ";
   }
 
   /* not case insensitive for unicode characters by default (ICU extension needed)

--- a/src/main/java/org/hibernate/dialect/SQLiteDialect.java
+++ b/src/main/java/org/hibernate/dialect/SQLiteDialect.java
@@ -319,11 +319,6 @@ public class SQLiteDialect extends Dialect {
     return true;
   }
 
-  @Override
-  public String getCascadeConstraintsString() {
-    return " ";
-  }
-
   /* not case insensitive for unicode characters by default (ICU extension needed)
   public boolean supportsCaseInsensitiveLike() {
     return true;


### PR DESCRIPTION
In my setup (Hibernate 5.0.2, Xerial-SQLite 3.8.11.2), I had to disable the cascaded table drop instruction. This might be relevant to others, too, so please consider a pull.