### PR TITLE
Use creation sql to create unique constraints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.github.gwenn</groupId>
   <artifactId>sqlite-dialect</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <name>SQLite dialect for Hibernate</name>
   <description>SQLite dialect for Hibernate</description>
   <url>https://github.com/gwenn/sqlite-dialect</url>

--- a/src/main/java/org/sqlite/hibernate/dialect/SQLiteDialect.java
+++ b/src/main/java/org/sqlite/hibernate/dialect/SQLiteDialect.java
@@ -366,6 +366,9 @@ public class SQLiteDialect extends Dialect {
 			return builder.toString();
 		}
 
+		/**
+		 * SQLite do not support 'alter table' to add constraints.
+		 */
 		@Override
 		public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata) {
 			return "";

--- a/src/main/java/org/sqlite/hibernate/dialect/SQLiteDialect.java
+++ b/src/main/java/org/sqlite/hibernate/dialect/SQLiteDialect.java
@@ -11,6 +11,7 @@ package org.sqlite.hibernate.dialect;
 
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Iterator;
 
 import org.hibernate.JDBCException;
 import org.hibernate.ScrollMode;
@@ -36,6 +37,8 @@ import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtracter;
 import org.hibernate.exception.spi.ViolatedConstraintNameExtracter;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Table;
+import org.hibernate.mapping.UniqueKey;
 import org.hibernate.type.StandardBasicTypes;
 import org.sqlite.hibernate.dialect.identity.SQLiteDialectIdentityColumnSupport;
 
@@ -330,6 +333,29 @@ public class SQLiteDialect extends Dialect {
 		@Override
 		public String getColumnDefinitionUniquenessFragment(Column column) {
 			return " unique";
+		}
+
+		@Override
+		public String getTableCreationUniqueConstraintsFragment(Table table) {
+			// get all uniqueKeys
+			StringBuilder builder = new StringBuilder();
+			Iterator<UniqueKey> iter = table.getUniqueKeyIterator();
+			while(iter.hasNext()) {
+				builder.append(", unique(");
+				UniqueKey key = iter.next();
+				Iterator<Column> columnIter = key.getColumnIterator();
+				int columnIndex = 0;
+				while(columnIter.hasNext()) {
+					Column column = columnIter.next();
+					if (columnIndex > 0) {
+						builder.append(",");
+					}
+					builder.append(column.getName());
+					columnIndex++;
+				}
+				builder.append(")");
+			}
+			return builder.toString();
 		}
 	}
 

--- a/src/main/java/org/sqlite/hibernate/dialect/SQLiteDialect.java
+++ b/src/main/java/org/sqlite/hibernate/dialect/SQLiteDialect.java
@@ -351,17 +351,8 @@ public class SQLiteDialect extends Dialect {
 			StringBuilder builder = new StringBuilder();
 			Iterator<UniqueKey> iter = table.getUniqueKeyIterator();
 			while(iter.hasNext()) {
-				builder.append(", unique(");
 				UniqueKey key = iter.next();
-				Iterator<Column> columnIter = key.getColumnIterator();
-				while(columnIter.hasNext()) {
-					Column column = columnIter.next();
-					builder.append(column.getName());
-					if (columnIter.hasNext()) {
-						builder.append(",");
-					}
-				}
-				builder.append(")");
+				builder.append(", ").append(uniqueConstraintSql(key));
 			}
 			return builder.toString();
 		}


### PR DESCRIPTION
Sqlite3 do not support alter table to add unique constraints, instead the unique constraints should be added on create-table sql.
Sqlite3 support unique constraints of multiple columns so the 'sqlite-dialect' should be changed to support this.
